### PR TITLE
Enable s3 web hosting so that user can access any subfolders without index.html

### DIFF
--- a/tf-static-website/22-cloudfront-frontend.tf
+++ b/tf-static-website/22-cloudfront-frontend.tf
@@ -1,19 +1,18 @@
-resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
-  comment  = "This is used for my website."
-  provider = aws.ops-blog
-}
-
 locals {
   s3_origin_id = "myS3Origin"
 }
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.ops_website.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.ops_website.website_endpoint
     origin_id   = local.s3_origin_id
+    origin_path = "/public"
 
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 

--- a/tf-static-website/99-output.tf
+++ b/tf-static-website/99-output.tf
@@ -1,12 +1,4 @@
 
-output "s3_bucket_domain" {
-    value = aws_s3_bucket.ops_website.bucket_domain_name
-}
-
-output "s3_bucket_regional_domain" {
-    value = aws_s3_bucket.ops_website.bucket_regional_domain_name
-}
-
-output "origin_access_identity" {
-    value = aws_cloudfront_origin_access_identity.origin_access_identity
+output "s3_bucket" {
+    value = aws_s3_bucket.ops_website
 }

--- a/tf-static-website/README.md
+++ b/tf-static-website/README.md
@@ -33,5 +33,7 @@ Error: error creating CloudFront Distribution: InvalidViewerCertificate: The spe
 <img alt="2020-03-06 Cloudfront & Route53" src="../docs/images/20200306-02-route53-cloudfront.png" width="300">
 
 ### How to access your blog?
-1. Upload a `index.html` file into your S3 bucket.
+1. Upload a `/public/index.html` file into your S3 bucket.
 2. Your contents won't be applied immediately and you need to wait for a while due to caching of cloudfront.
+
+You can also have the default 404 page with uploading a `/public/404.html` file.


### PR DESCRIPTION
Enable s3 web hosting so that user can access any subfolders without index.html


https://amezou.com/existpage/ should be redirected to an existing page.
https://amezou.com/nonexitspage/ should be redirected to a default 404 page.